### PR TITLE
Build core before serverless (fixes #2)

### DIFF
--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "vite",
+    "prebuild": "npm run build --prefix ../core",
     "build": "vite build --mode client && vite build",
     "preview": "wrangler pages dev",
     "deploy": "npm run build && wrangler pages deploy",


### PR DESCRIPTION
this pull request fixes #2 . Build script of `packages/core` will be run before build process of `packages/serverless`.